### PR TITLE
Change 'canonicalize' to 'canonicalize_path'

### DIFF
--- a/src/binmap.cpp
+++ b/src/binmap.cpp
@@ -155,7 +155,7 @@ public:
   }
 };
 
-struct canonicalize {
+struct canonicalize_path {
 
   void operator()(boost::filesystem::path &path) const {
     path = boost::filesystem::canonical(path, ".");
@@ -176,13 +176,13 @@ class ScanCommand : public SubCommand {
     else {
       str_inputs = vm_["inputs"].as<std::vector<std::string> >();
       std::copy(str_inputs.begin(), str_inputs.end(), std::back_inserter(inputs));
-      std::for_each(inputs.begin(), inputs.end(), canonicalize());
+      std::for_each(inputs.begin(), inputs.end(), canonicalize_path());
     }
 
     std::vector<boost::filesystem::path> blacklist;
     if (vm_.count("exclude") != 0)
       blacklist = vm_["exclude"].as<std::vector<boost::filesystem::path> >();
-    std::for_each(blacklist.begin(), blacklist.end(), canonicalize());
+    std::for_each(blacklist.begin(), blacklist.end(), canonicalize_path());
 
     boost::filesystem::path output;
     if (vm_.count("output") != 0)


### PR DESCRIPTION
When compiling with ``clang 4.0.0`` (``libstdc++ 3.4.23`` - Archlinux ``4.11.6``) I have the following conflict

```bash
binmap/src/binmap.cpp:187:70: error: trop peu d'arguments pour la fonction « int canonicalize(double*, const double*) »
     std::for_each(blacklist.begin(), blacklist.end(), ::canonicalize());
                                                                      ^
In file included from /usr/include/features.h:410:0,
                 from /usr/include/c++/7.1.1/x86_64-pc-linux-gnu/bits/os_defines.h:39,
                 from /usr/include/c++/7.1.1/x86_64-pc-linux-gnu/bits/c++config.h:533,
                 from /usr/include/c++/7.1.1/iostream:38,
                 from dev/binmap/include/binmap/log.hpp:20,
                 from dev/binmap/src/binmap.cpp:22:
/usr/include/bits/mathcalls.h:435:1: note: déclaré ici
 __MATHDECL_1 (int, canonicalize,, (_Mdouble_ *__cx, const _Mdouble_ *__x));
```